### PR TITLE
Linux and Windows compatible identification of main script file name

### DIFF
--- a/pemfc/src/output.py
+++ b/pemfc/src/output.py
@@ -7,7 +7,9 @@ import matplotlib
 import matplotlib.pyplot as plt
 import timeit
 import json
-import __main__ as main
+import sys
+
+
 
 
 # local module imports
@@ -17,10 +19,9 @@ from . import stack as stack
 from ..data import input_dicts
 
 # configure backend here
-main_name = os.path.basename(main.__file__)
-if main_name == 'main_app.py':
+main_name=sys.argv[0]
+if 'main_app.py' in main_name:
     matplotlib.use('TkAgg')
-
 
 # globals
 FONT_SIZE = 14

--- a/pemfc/src/output.py
+++ b/pemfc/src/output.py
@@ -9,9 +9,6 @@ import timeit
 import json
 import sys
 
-
-
-
 # local module imports
 from . import interpolation as ip
 from . import global_functions as g_func


### PR DESCRIPTION
os.path.basename(main.__ file __) seems not to work at Linux or et least not at Ubuntu 20.04:
![image](https://user-images.githubusercontent.com/94350939/150523776-0d2505c6-e736-4df8-8308-381fa5431ad5.png)

I found out that...

1. __ main __ has not always a __ file __ attribute. [https://stackoverflow.com/questions/606561/how-to-get-filename-of-the-main-module-in-python] 
2. output of __ file __ recently changed:
"From Python3.9 onwards, per issue 20443, the __file__ attribute of the __main__ module became an absolute path, rather than a relative path." [https://stackoverflow.com/questions/4152963/get-name-of-current-script-in-python]

Solution based on:
https://stackoverflow.com/questions/4152963/get-name-of-current-script-in-python

Check for substring
`if 'main_app.py' in main_name:`
 is requied due to different return of sys.argv[0] in Linux and Windows.


