### PR TITLE
global outputs fix for single cell

### DIFF
--- a/pemfc/settings/geometry.py
+++ b/pemfc/settings/geometry.py
@@ -2,7 +2,7 @@
 
 """Stack Settings"""
 # number of cells in the stack
-cell_number = 10
+cell_number = 1
 
 """"Cell Geometry """
 # length of the cell, a side of the active area [m]
@@ -62,7 +62,7 @@ anode_flow_direction = -1
 # set boolean to calculate coolant flow
 coolant_circuit = True
 # set boolean for coolant flow between the edge cells and endplates
-cooling_bc = True
+cooling_bc = False
 # channel length [m]
 coolant_channel_length = 0.5
 # height of the coolant channel [m]

--- a/pemfc/src/simulation.py
+++ b/pemfc/src/simulation.py
@@ -154,6 +154,10 @@ class Simulation:
             average_current_density = \
                 np.average([np.average(cell.i_cd, weights=cell.active_area_dx)
                             for cell in self.stack.cells])
+            if self.stack.coolant_circuit is None:
+                cool_mass_flow = 0.0
+            else:
+                cool_mass_flow = self.stack.coolant_circuit.mass_flow_in
             global_data = \
                 {'Stack Voltage': {'value': self.stack.v_stack, 'units': 'V'},
                  'Average Cell Voltage':
@@ -173,7 +177,7 @@ class Simulation:
                       * self.stack.cells[0].active_area,
                       'units': 'W'},
                  'Cooling Mass Flow Rate:':
-                     {'value': self.stack.coolant_circuit.mass_flow_in,
+                     {'value': cool_mass_flow,
                       'units': 'kg/s', 'format': '.4E'},
                  'Cathode Mass Flow Rate:':
                      {'value': self.stack.fuel_circuits[0].mass_flow_in,


### PR DESCRIPTION
Simulation without cooling caused AttributeError in the global output dictionary. Is now replaced with previous checking and setting to zero mass flow if coolant circuit is None