### PR TITLE
removed underrelaxation_factor for membrane, supposed default usage

### DIFF
--- a/pemfc/settings/settings.json
+++ b/pemfc/settings/settings.json
@@ -27,7 +27,6 @@
     "membrane": {
         "type": "YeWang2007",
         "thickness": 1.5e-05,
-        "underrelaxation_factor": 0.8,
         "ionic_conductivity": 15.0,
         "basic_resistance": 4.3e-05,
         "temperature_coefficient": 7e-08,


### PR DESCRIPTION
Removed membrane "underrelaxation_factor" from settings.json so that it does not overwrite the different default underrelaxation factors for different membrane models. If provided with the settings.json it should be controllable from the dash-app input as well.